### PR TITLE
Linkedchangesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ First we make a changeset:
 ```
 const EX = 'http://example.info/'
 const changeset = {
-    // date 
-     created: new Date().toISOString(),
     // an array of triples/quads to add
      add: [{s: EX+'123', p: EX+'count', o_value: 0, o_type:'literal', o_datatype: EX+'integer', g: EX+'graphs/graph-name'}]
     // triples/quads to remove (changeset will fail if they don't exist)
@@ -84,7 +82,6 @@ changsetSparql(changeset, {
 - *add*: optional, must be an Array of quads to be added to the dataset
 - *remove*: optional, must be an Array of quads to be removed from the dataset
 - *previous*: optional, must be an Array of URIs of latest changesets of each _subject_ 
-- *created*: optional, must be a full date time (including date, time, seconds, timezone)
 
 #### Triple/Quad Specification
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ const changeset = {
      add: [{s: EX+'123', p: EX+'count', o_value: 0, o_type:'literal', o_datatype: EX+'integer', g: EX+'graphs/graph-name'}]
     // triples/quads to remove (changeset will fail if they don't exist)
    , remove: [{s: EX+'987', p: EX+'message',  o_value: "Hello", o_type:'literal', o_lang: 'en-gb'}]
-    // triples/quads to create (changeset will fail if s & p already exist)
+    // the URIs of the latest changesets for each subject we want to change
    , previous: ["urn:hash:sha1:jkhjkhkj2kjh3", "urn:hash:sha1:mnwejkljh7898c"],
-   // the URIs of the latest changesets for each subject we want to change
+
 }
 ```
 
@@ -85,7 +85,7 @@ changsetSparql(changeset, {
 
 #### Triple/Quad Specification
 
-(format of the objects in the `add` `remove` `create` Arrays)
+(format of the objects in the `add` and `remove` Arrays)
 
 - *s*: required, URI (subject)
 - *p*: required, URI (predicate/property)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ const changeset = {
     // triples/quads to remove (changeset will fail if they don't exist)
    , remove: [{s: EX+'987', p: EX+'message',  o_value: "Hello", o_type:'literal', o_lang: 'en-gb'}]
     // triples/quads to create (changeset will fail if s & p already exist)
-   , create: [{s: EX+'987', p: EX+'link',  o_value: EX+"678", o_type:'uri'}],
+   , previous: ["urn:hash:sha1:jkhjkhkj2kjh3", "urn:hash:sha1:mnwejkljh7898c"],
+   // the URIs of the latest changesets for each subject we want to change
 }
 ```
 
@@ -80,10 +81,10 @@ changsetSparql(changeset, {
  
 ### Changeset Object Specification
 
-- *created*: required, must be a full date time (including date, time, seconds, timezone)
 - *add*: optional, must be an Array of quads to be added to the dataset
 - *remove*: optional, must be an Array of quads to be removed from the dataset
-- *create*: optional, must be an Array of quads to be added to the dataset if the `graph` `subject` `predicate` combination does not already exist
+- *previous*: optional, must be an Array of URIs of latest changesets of each _subject_ 
+- *created*: optional, must be a full date time (including date, time, seconds, timezone)
 
 #### Triple/Quad Specification
 

--- a/example.js
+++ b/example.js
@@ -3,6 +3,7 @@ const applyChangset = require('./index.js')
 const EX = 'http://example.info/'
 const changeset = {
     created: new Date().toISOString(),
+    previous: ['urn:hash:sha1:f162b8f1831780437c4f4e8f47d7473434dd4777'],
 //    create: [{s: EX+'123', p: EX+'count', o_value: 0, o_type:'literal', o_datatype: EX+'integer'}]
 //   , remove: [{s: EX+'987', p: EX+'message',  o_value: "Hello", o_type:'literal', o_lang: 'en-gb'}]
     add: [{s: EX+'987', p: EX+'link',  o_value: EX+"678", o_type:'uri'}],
@@ -21,7 +22,7 @@ const changeset = {
 
 
 const request = require('request')
-const endpoint = 'http://localhost:3030/TestData'
+const endpoint = 'http://localhost:3030/test'
 const sparqlEndpoint = endpoint+'/sparql'
 const updateEndpoint = endpoint+'/update'
 const query = (q, callback) => request({

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const Task = {
 const pipeWith = chain => (...funcs) => funcs.reduce((f, g) => x => chain(g)(f(x)))
 const pipe = pipeWith(Task.chain)
 
-module.exports = function applyChangesetConfig(sparqlQueryNode, sparqlUpdateNode){
+module.exports = function applyChangesetWith(sparqlQueryNode, sparqlUpdateNode){
     
     const sparqlQuery = Task.fromNodeStyle(sparqlQueryNode)
     const sparqlUpdate = Task.fromNodeStyle(sparqlUpdateNode)
@@ -17,12 +17,14 @@ module.exports = function applyChangesetConfig(sparqlQueryNode, sparqlUpdateNode
     return function applyChangeset(changeset, callbacks){
         const id = sha1(JSON.stringify(changeset))
         const changesetURI = 'urn:hash:sha1:'+id
-        const arrayKeys = ['remove', 'add', 'create']
+        const arrayKeys = ['remove', 'add']
         arrayKeys.forEach(k => changeset[k]=changeset[k]||[])
         const changegraph = 'app://graphs/changesets'
         const previous = changeset.previous || []
         const prev = previous.length? 
             `; cs:previousChangeSet ${changeset.previous.map(s => `<${s}>`).join(', ')}` : ``
+
+        const subjects = unique([...changeset.remove.map(getSubject), ...changeset.add.map(getSubject)])
         const update = `
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX cs: <http://purl.org/vocab/changeset/schema#>
@@ -42,6 +44,9 @@ DELETE {
     FILTER NOT EXISTS { 
         GRAPH <${changegraph}> { <${changesetURI}> dc:dateAccepted ?date . }
     }
+    GRAPH <${changegraph}> {
+        ${checkCandidateIsLatest(previous, subjects)}
+    }
 }
         `
         const confirmationQuery = `ASK WHERE { GRAPH <${changegraph}> { <${changesetURI}> ?p ?o } }`
@@ -57,6 +62,48 @@ DELETE {
                 callbacks.ok(changesetURI) : callbacks.rejected("Changeset Rejected "+ update)
         )
     }
+}
+
+//this query snippet could be a little simpler if we changed the changeset format to something like
+//[
+//  {
+//      subject: URI,
+//      previousChangeSet: URI,
+//      add: [ {p, o, g} ],
+//      remove: [ {p, o, g} ]
+//  }
+//  
+//]
+//though some of the other insertion logic might be trickier
+//- we still need the whole batch to fail if one fails
+
+function checkCandidateIsLatest(previous, subjects){
+    return subjects.map((s, i) => `
+    { 
+       FILTER NOT EXISTS { ?latest_${i} cs:subjectOfChange <${s}> . }
+    }
+    UNION {
+        ?latest_${i} cs:subjectOfChange <${s}> .
+        FILTER NOT EXISTS { 
+            ?newer_${i} cs:previousChangeSet ?latest_${i} 
+            ; cs:subjectOfChange <${s}> 
+        }
+        FILTER(?latest_${i} IN (${previous.map(p=>`<${p}>`).join(', ')}))
+    }
+    `).join('\n')
+}
+
+function unique(arr){
+    const len = arr.length
+    const output = []
+    for(var i =0; i < len; i++){
+        if(output.indexOf(arr[i]) === -1) output.push(arr[i])
+    }
+    return output
+}
+
+function getSubject(quad){
+    return quad.s
 }
 
 function checkQueryResponse(response){

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "sha1": "^1.1.1"
   },
   "devDependencies": {
+    "fluture": "^5.0.0",
+    "rdfstore": "^0.9.17",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "sha1": "^1.1.1"
   },
   "devDependencies": {
-    "fluture": "^5.0.0",
-    "rdfstore": "^0.9.17",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/kwijibo/changeset-sparql#readme",
   "dependencies": {
     "sha1": "^1.1.1"
+  },
+  "devDependencies": {
+    "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": " applies a changeset via SPARQL Update ",
   "main": "index.js",
   "scripts": {
-    "test": "tape tests/**/*.js"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changeset-sparql",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": " applies a changeset via SPARQL Update ",
   "main": "index.js",
   "scripts": {

--- a/test-sparql.js
+++ b/test-sparql.js
@@ -1,0 +1,98 @@
+const request = require('request')
+
+const setupInsert = `
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX : <http://data.smoke-mirrors.co.uk/def/>
+PREFIX cs: <http://purl.org/vocab/changeset/schema#>
+BASE <http://example.info/>
+PREFIX c: <changes/>
+PREFIX s: <resources/>
+
+DROP ALL;
+
+INSERT DATA {
+c:_1 cs:subjectOfChange s:A, s:B .	
+c:_2 cs:subjectOfChange s:C .	
+c:_3 cs:subjectOfChange s:A ; cs:previousChangeSet c:_1 .
+}
+`
+const tests = `
+ [ cs:subjectOfChange s:A, s:B ; cs:previousChangeSet c:_1, c:_3 ] #good
+ [ cs:subjectOfChange s:A, s:B ; cs:previousChangeSet c:_1, c:_2 ] #bad
+ [ cs:subjectOfChange s:A, s:C ; cs:previousChangeSet c:_1, c:_2 ] #bad
+ [ cs:subjectOfChange s:A, s:C ; cs:previousChangeSet c:_1, c:_3 ] #bad
+ [ cs:subjectOfChange s:A, s:C ; cs:previousChangeSet c:_2, c:_3 ] #good
+ [ cs:subjectOfChange s:B, s:C ; cs:previousChangeSet c:_2, c:_3 ] #bad
+ [ cs:subjectOfChange s:B, s:C ; cs:previousChangeSet c:_1, c:_2 ] #good
+ [ cs:subjectOfChange s:A ; cs:previousChangeSet c:_3 ] #good
+ [ cs:subjectOfChange s:A ; cs:previousChangeSet c:_1 ] #bad
+ [ cs:subjectOfChange s:Z  ] #good
+`
+console.log(setupInsert)
+runUpdate(setupInsert)
+(runTests)
+
+function runTests(){
+    tests
+    .trim()
+    .split('\n')
+    .map(line => ({ line
+        , subjects: line.match(/s:[A-Z]/g)
+        , expected: line.match(/(bad)|(good)/)[0]
+        , prev: line.match(/c:_[0-9]/g) || []})
+    ).map(data => ({data,  query: csToSparql(data)}))
+    .forEach(x => runQuery(x.query)(actual => {
+        const expected = (x.data.expected==='good')
+        const msg = (actual===expected)? 'Passed.' : 'Failed: expected '+JSON.stringify(expected)+ ' got: '+actual  
+        console.log(msg, x.data.line)
+    }))
+}
+
+function csToSparql(cs){
+    return `
+PREFIX cs: <http://purl.org/vocab/changeset/schema#>
+BASE <http://example.info/>
+PREFIX c: <changes/>
+PREFIX s: <resources/>
+ASK WHERE { 
+    ${cs.subjects.map((s, i) => `
+    { 
+       FILTER NOT EXISTS { ?latest_${i} cs:subjectOfChange ${s} . }
+    }
+    UNION {
+        ?latest_${i} cs:subjectOfChange ${s} .
+        FILTER NOT EXISTS { 
+            ?newer_${i} cs:previousChangeSet ?latest_${i} 
+            ; cs:subjectOfChange ${s} 
+        }
+        FILTER(?latest_${i} IN (${cs.prev.join(', ')}))
+    }
+`).join('\n')}
+}`
+}
+
+function runQuery(query){
+    return callback => request({
+        url: 'http://localhost:3030/test/sparql',
+        qs: {query: query},
+        headers: {Accept: "application/sparql-results+json"}
+    }, function(err, data){
+        if(!err && data.statusCode!=200) err = new Error(data.body)
+//        console.log("runQuery", query, err, data.body)
+        ;(err || data.statusCode!=200)? console.error(err) : callback(JSON.parse(data.body).boolean)
+    })
+}
+
+function runUpdate(update){
+    return callback => request({
+        url: 'http://localhost:3030/test/update',
+        body: update,
+        method: 'POST',
+        headers: {'Content-type': "application/sparql-update"}
+    }, function(err, data, body){
+        if(!err && data.statusCode!=204) err = new Error(data.body)
+        ;(err)? console.error(err, data.body) : callback(data.body)
+    })
+
+}
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,106 @@
+const test = require('tape');
+const NS = 'urn:id:string:'
+const request = require('request')
+const endpoint = 'http://localhost:3030/test'
+const sparqlEndpoint = endpoint+'/sparql'
+const updateEndpoint = endpoint+'/update'
+
+const httpQuery = (q, callback) => request({
+    url: sparqlEndpoint,
+    body: q,
+    method: 'POST',
+    headers: {
+        'Accept': 'application/sparql-results+json',
+        'Content-type': 'application/sparql-query'
+    }
+}, (err, data)=> err? callback(err) : callback(null, JSON.parse(data.body)))
+
+const httpUpdate = (q, callback) => request({
+    url: updateEndpoint,
+    body: q,
+    method: 'POST',
+    headers: {
+        'Accept': 'application/sparql-results+json',
+        'Content-type': 'application/sparql-update'
+    }
+}, callback)
+const applyChangeset = require('./index.js')(httpQuery, httpUpdate)
+
+test('Reject changesets removing triples that do not exist', function (t) {
+    t.plan(1)
+    const changeset = removeResources([], [{id: "a", name: "A", foo: "bar"}, {id: "b", name: "B"}])
+    applyChangeset(changeset, {
+        error: x => t.fail(x),
+        ok: x => t.fail("changeset not rejected "+x),
+        rejected: x => t.pass("changeset rejected")
+    })
+})
+test('creating new resources', function (t) {
+    t.plan(3)
+    const initial = [{id: "a", name: "A", foo: "bar"}, {id: "b", name: "B"}]
+    const afterEdit = [{id: "a", name: "X", foo: "baz"}, {id: "b", name: "Y"}] 
+    const changeset = createResources(initial)
+    httpUpdate('DROP ALL;', function resourceCreation(err, data){
+        if(err) return console.error(err)
+        changesetSuccess(changeset, uri=>{
+            t.pass("resources created")
+            const editChangeset = editResources([uri], initial, afterEdit)
+            changesetSuccess(editChangeset, editUri => {
+                t.pass("resources edited")
+                const deleteChangeset = removeResources([editUri], afterEdit)
+                changesetSuccess(deleteChangeset, delUri=> {
+                    t.pass("resource deleted")
+                })
+            })
+        })
+    })
+})
+
+function changesetSuccess(changeset, okCallback){
+    applyChangeset(changeset, {
+            error: x => t.fail(x),
+            ok: okCallback,
+            rejected: x => t.fail("changeset rejected")
+    })
+}
+
+function changesetFail(changeset,rejectedkCallback){
+    applyChangeset(changeset, {
+            error: x => t.fail(x),
+            ok: t.fail("changeset should have been rejected"),
+            rejected: rejectedCallback
+    })
+}
+
+
+function createResources(resources){
+    return {
+        created: new Date().toISOString(),
+        add: resourcesToTriples(resources)    
+    }
+}
+
+function editResources(previous, befores, afters){
+    return {
+        previous,
+        remove: resourcesToTriples(befores),
+        add: resourcesToTriples(afters)
+    }
+}
+
+function removeResources(previous, resources){
+    return {
+        previous,
+        remove: resourcesToTriples(resources)
+    }
+}
+
+function resourcesToTriples(resources){
+    return resources.map(pojo => Object.keys(pojo)
+                .filter(k=>k!='id')
+                .map(k => ({s: NS+pojo.id, p: NS+k, o_value: pojo[k], o_type: 'literal' }))
+             ).reduce((result, item) => [...result, ...item], [])
+}
+
+
+


### PR DESCRIPTION
this goes from using dates to give changesets some unique form of identity, to linking to the preceding changesets instead. This changes the changeset acceptance criteria:

1. Changeset will be rejected if all removal triples are not present
2. Changesets that have already been accepted will be accepted again, but will have no further effect.

adding:

3.  Changesets must prove they have seen the latest changeset for each resource they are changing by including the changeset URIs in a `previous` Array field. 